### PR TITLE
Updated cmplsp capabilities method, working

### DIFF
--- a/.config/nvim/fnl/config/plugin/lspconfig.fnl
+++ b/.config/nvim/fnl/config/plugin/lspconfig.fnl
@@ -35,7 +35,7 @@
                 (vim.lsp.with
                   vim.lsp.handlers.signature_help
                   {:border "single"})}
-      capabilities (cmplsp.update_capabilities (vim.lsp.protocol.make_client_capabilities))
+      capabilities (cmplsp.default_capabilities)
       on_attach (fn [client bufnr]
                   (do
                     (nvim.buf_set_keymap bufnr :n :gd "<Cmd>lua vim.lsp.buf.definition()<CR>" {:noremap true})


### PR DESCRIPTION
Tried to install the Practicalli Neovim config, but there was a [breaking change in nvim-cmp-lsp](https://github.com/hrsh7th/cmp-nvim-lsp/issues/38) that caused lspconfig.fnl to fail. Updated the file so after a round of packer install and packer update, it looks good to go.

The theme is still a light theme, but I'm not getting any errors about it, so maybe github-theme has a light mode I'm not aware of?